### PR TITLE
Added missing invoice properties

### DIFF
--- a/NBitpayClient/Invoice.cs
+++ b/NBitpayClient/Invoice.cs
@@ -383,9 +383,21 @@ namespace NBitpayClient
 		}
 		public bool ShouldSerializePaymentCodes() { return false; }
 
-	}
+        public string TransactionCurrency { get; set; }
+        public bool ShouldSerializeTransactionCurrency() { return false; }
 
-	class Flags
+        public List<RefundInfo> RefundInfo { get; set; }
+        public bool ShouldSerializeRefundInfo() { return false; }
+
+        public bool RefundAddressRequestPending { get; set; }
+        public bool ShouldSerializeRefundAddressRequestPending() { return false; }
+
+        public List<Dictionary<string, RefundAddress>> RefundAddresses { get; set; }
+        public bool ShouldSerializeRefundAddresses() { return false; }
+
+    }
+
+    class Flags
 	{
 		public bool Refundable { get; set; }
 	}

--- a/NBitpayClient/InvoiceTransaction.cs
+++ b/NBitpayClient/InvoiceTransaction.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace NBitpayClient
 {
@@ -16,12 +17,15 @@ namespace NBitpayClient
         public string Confirmations { get; set; }
 
         [JsonProperty(PropertyName = "receivedTime")]
-        public string ReceivedTime { get; set; }
+        public DateTimeOffset ReceivedTime { get; set; }
 
         [JsonProperty(PropertyName = "time")]
         public string Time { get; set; }
 
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "txid")]
+        public string TxId { get; set; }
     }
 }

--- a/NBitpayClient/RefundAddress.cs
+++ b/NBitpayClient/RefundAddress.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace NBitpayClient
+{
+    public class RefundAddress
+    {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "date")]
+        public DateTimeOffset Date { get; set; }
+    }
+}


### PR DESCRIPTION
The following is an example of the JSON returned for a `GET /invoices/{id}` call to the BitPay API.

<details>
<summary>Toggle GET /invoices/{id} JSON Response</summary>

```
{
   "facade":"merchant/invoice",
   "data":{
      "url":"https://test.bitpay.com/invoice?id=***************",
      "posData":"some data",
      "status":"complete",
      "price":10,
      "currency":"USD",
      "itemDesc":"Item Desc",
      "invoiceTime":1550840708425,
      "expirationTime":1550841608425,
      "currentTime":1550931615822,
      "guid":"********************",
      "id":"***************",
      "lowFeeDetected":false,
      "amountPaid":254200,
      "exceptionStatus":false,
      "transactions":[
         {
            "amount":254200,
            "confirmations":6,
            "receivedTime":"2019-02-22T13:05:36.481Z",
            "txid":"***********************",
            "exRates":{
               "BTC":1,
               "USD":3933.84,
               "BCH":27.54789915966386
            },
            "outputIndex":1
         }
      ],
      "buyer":{
         "email":"test@example.com"
      },
      "redirectURL":"https://google.com",
      "refundAddresses":[
         {
            "********************":{
               "type":"buyerSupplied",
               "date":"2019-02-22T14:02:59.595Z"
            }
         }
      ],
      "refundAddressRequestPending":false,
      "buyerProvidedEmail":"test@example.com",
      "buyerProvidedInfo":{
         "selectedTransactionCurrency":"BTC",
         "emailAddress":"test@example.com"
      },
      "paymentSubtotals":{
         "BTC":254200,
         "BCH":7007700
      },
      "paymentTotals":{
         "BTC":254200,
         "BCH":7007700
      },
      "exchangeRates":{
         "BTC":{
            "USD":3933.84,
            "BCH":27.54789915966386
         },
         "BCH":{
            "USD":142.7,
            "BTC":0.03627950729022334
         }
      },
      "minerFees":{
         "BTC":{
            "satoshisPerByte":0,
            "totalFee":0
         },
         "BCH":{
            "satoshisPerByte":0,
            "totalFee":0
         }
      },
      "transactionCurrency":"BTC",
      "supportedTransactionCurrencies":{
         "BTC":{
            "enabled":true
         },
         "BCH":{
            "enabled":true
         }
      },
      "paymentCodes":{
         "BTC":{
            "BIP72b":"bitcoin:?r=https://test.bitpay.com/i/***************",
            "BIP73":"https://test.bitpay.com/i/***************"
         },
         "BCH":{
            "BIP72b":"bitcoincash:?r=https://test.bitpay.com/i/***************",
            "BIP73":"https://test.bitpay.com/i/***************"
         }
      },
      "token":"****************"
   }
}
```

</details>

-------------

I found several useful things (for my use case, at least) missing from the invoice object. This PR adds them so that they can be used.

1. Added `TxId` to invoice transaction object.
2. Changed transaction `ReceivedTime` to a proper `DateTimeOffset` type.
4. Added `RefundAddressRequestPending` to invoice object.
5. Added `RefundAddresses` array to invoice object, along with its new object class for `RefundAddress`.
6. Added `RefundInfo` array as documented at https://bitpay.com/api#resource-Invoices
7. Added `TransactionCurrency` string as documented at https://bitpay.com/api#resource-Invoices