### PR TITLE
Fixed totals for currencies with extremely small base units (ex. ETH).

### DIFF
--- a/NBitpayClient/Invoice.cs
+++ b/NBitpayClient/Invoice.cs
@@ -16,7 +16,7 @@ namespace NBitpayClient
 			get; set;
 		}
 		[JsonProperty("totalFee")]
-		public long TotalFee
+		public decimal TotalFee
 		{
 			get; set;
 		}
@@ -380,10 +380,10 @@ namespace NBitpayClient
 		private Flags Flags { get; set; }
 		public virtual bool ShouldSerializeFlags() { return false; }
 
-		public Dictionary<string, long> PaymentSubtotals { get; set; }
+		public Dictionary<string, decimal> PaymentSubtotals { get; set; }
 
-		public Dictionary<string, long> PaymentTotals { get; set; }
-		public long AmountPaid { get; set; }
+		public Dictionary<string, decimal> PaymentTotals { get; set; }
+		public decimal AmountPaid { get; set; }
 
 		public Dictionary<string, Dictionary<string, decimal>> ExchangeRates { get; set; }
 

--- a/NBitpayClient/InvoicePaymentNotification.cs
+++ b/NBitpayClient/InvoicePaymentNotification.cs
@@ -119,12 +119,12 @@ namespace NBitpayClient
 	        get; set;
 	    }
 	    [JsonProperty(PropertyName = "paymentSubtotals")]
-	    public Dictionary<string, long> PaymentSubtotals
+	    public Dictionary<string, decimal> PaymentSubtotals
         {
 	        get; set;
 	    }
 	    [JsonProperty(PropertyName = "paymentTotals")]
-	    public Dictionary<string,long> PaymentTotals
+	    public Dictionary<string, decimal> PaymentTotals
         {
 	        get; set;
 	    }


### PR DESCRIPTION
The smallest unit of Ethereum is the Wei, [which is 1/1,000,000,000,000,000,000 of an ETH](https://coinmine.com/blogs/news/what-is-wei-the-smallest-ethereum-unit-explained). Decimal allows for room to grow:

```
Wei/ETH                       1,000,000,000,000,000,000
Decimal.MaxValue 79,228,162,514,264,337,593,543,950,335
```

Fixes #24.